### PR TITLE
Allow for different source and destination delimiters. (Fix for #14)

### DIFF
--- a/imapcopy.py
+++ b/imapcopy.py
@@ -153,6 +153,12 @@ class IMAP_Copy(object):
                 msg = email.message_from_string(message);
                 msgDate = email.utils.parsedate(msg['Date'])
 
+                # Attempt to correct for negative hour values
+                if msgDate[3] < 0:
+                  newDate = list(msgDate)
+                  newDate[3] = 24 + newDate[3]
+                  msgDate = tuple(newDate)
+
                 self._conn_destination.append(
                     destination_mailbox, flags, msgDate, message
                 )

--- a/imapcopy.py
+++ b/imapcopy.py
@@ -32,7 +32,7 @@ class IMAP_Copy(object):
 
     def __init__(self, source_server, destination_server, mailbox_mapping,
                  source_auth=(), destination_auth=(), create_mailboxes=False,
-                 recurse=False, skip=0, limit=0):
+                 recurse=False, skip=0, limit=0, no_messages=False):
 
         self.logger = logging.getLogger("IMAP_Copy")
 
@@ -46,6 +46,7 @@ class IMAP_Copy(object):
 
         self.skip = skip
         self.limit = limit
+        self.no_messages = no_messages
 
         self.recurse = recurse
 
@@ -128,6 +129,9 @@ class IMAP_Copy(object):
             self._conn_destination.subscribe(destination_mailbox)
             status, data = self._conn_destination.select(destination_mailbox)
 
+        if self.no_messages:
+            return
+
         # Look for mails
         self.logger.info("Looking for mails in %s" % source_mailbox)
         status, data = self._conn_source.search(None, 'ALL')
@@ -200,6 +204,8 @@ def main():
     parser.add_argument('-c', '--create-mailboxes', dest='create_mailboxes',
                         action="store_true", default=False,
                         help='Create the mailboxes on destination')
+    parser.add_argument('-n', '--no-messages', action="store_true", default=False,
+                        help="don't copy messages (use with --create-mailboxes to only create folder structure)")
     parser.add_argument('-r', '--recurse', dest='recurse', action="store_true",
                         default=False, help='Recurse into submailboxes')
     parser.add_argument('-q', '--quiet', action="store_true", default=False,
@@ -241,7 +247,8 @@ def main():
 
     imap_copy = IMAP_Copy(source, destination, mailbox_mapping, source_auth,
                           destination_auth, create_mailboxes=args.create_mailboxes,
-                          recurse=args.recurse, skip=args.skip, limit=args.limit)
+                          recurse=args.recurse, skip=args.skip, limit=args.limit,
+                          no_messages=args.no_messages)
 
     streamHandler = logging.StreamHandler()
     formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')

--- a/imapcopy.py
+++ b/imapcopy.py
@@ -67,7 +67,7 @@ class IMAP_Copy(object):
         self.logger.info("%s connection established" % target)
         # Detecting delimiter on destination server
         code, mailbox_list = connection.list()
-        self.delimiter = mailbox_list[0].split('"')[1]
+        setattr(self, '_%s_delimiter' % target, mailbox_list[0].split('"')[1])
 
     def connect(self):
         self._connect('source')
@@ -98,10 +98,10 @@ class IMAP_Copy(object):
             for d in data:
                 if d:
                     new_source_mailbox = d.split('"')[3]  # Getting submailbox name
-                    if new_source_mailbox.count('/') == recurse_level:
+                    if new_source_mailbox.count(self._source_delimiter) == recurse_level:
                         self.logger.info("Recursing into %s" % new_source_mailbox)
-                        new_destination_mailbox = new_source_mailbox.split("/")[recurse_level]
-                        self.copy(new_source_mailbox, destination_mailbox + self.delimiter + new_destination_mailbox,
+                        new_destination_mailbox = new_source_mailbox.split(self._source_delimiter)[recurse_level]
+                        self.copy(new_source_mailbox, (destination_mailbox + self._destination_delimiter if destination_mailbox else "") + new_destination_mailbox,
                                   skip, limit, recurse_level + 1)
 
         # There should be no files stored in / so we are bailing out


### PR DESCRIPTION
Correctly track and use separators for each server.