### PR TITLE
Fixed issue with messages that have a negative hour value (Fix for #17)

### DIFF
--- a/imapcopy.py
+++ b/imapcopy.py
@@ -153,6 +153,12 @@ class IMAP_Copy(object):
                 msg = email.message_from_string(message);
                 msgDate = email.utils.parsedate(msg['Date'])
 
+                # Attempt to correct for negative hour values
+                if msgDate[3] < 0:
+                  newDate = list(msgDate)
+                  newDate[3] = 24 + newDate[3]
+                  msgDate = tuple(newDate)
+
                 self._conn_destination.append(
                     destination_mailbox, flags, msgDate, message
                 )

--- a/imapcopy.py
+++ b/imapcopy.py
@@ -154,7 +154,7 @@ class IMAP_Copy(object):
                 msgDate = email.utils.parsedate(msg['Date'])
 
                 # Attempt to correct for negative hour values
-                if msgDate[3] < 0:
+                if msgDate and msgDate[3] < 0:
                   newDate = list(msgDate)
                   newDate[3] = 24 + newDate[3]
                   msgDate = tuple(newDate)


### PR DESCRIPTION
This fixes issue #17.  I choose to add 24 to the negative value effectively "wrapping" around midnight.  Additional checks could be added to ensure the absolute value is in range.  Such checks could be applied to all the date fields.  That might be appropriate for another pull request.