### PR TITLE
Correctly parse mailbox name even when server doesn't use quotes. (Fix for #13)

### DIFF
--- a/imapcopy.py
+++ b/imapcopy.py
@@ -97,7 +97,9 @@ class IMAP_Copy(object):
             typ, data = connection.list(source_mailbox)
             for d in data:
                 if d:
-                    new_source_mailbox = d.split('"')[3]  # Getting submailbox name
+                    index1 = d.find('"')
+                    index2 = d.find('"', index1 + 1)
+                    new_source_mailbox = d[index2:].strip(' "')
                     if new_source_mailbox.count('/') == recurse_level:
                         self.logger.info("Recursing into %s" % new_source_mailbox)
                         new_destination_mailbox = new_source_mailbox.split("/")[recurse_level]


### PR DESCRIPTION
This assumes the imap prefix is quoted and that there are not quotes in the flags.  Thus we can find the mailbox name by finding the second quote.  This works when the mailbox name is quoted and when it is not quoted.