### PR TITLE
Fix recursion bug, issue #2

### DIFF
--- a/imapcopy.py
+++ b/imapcopy.py
@@ -97,12 +97,15 @@ class IMAP_Copy(object):
             typ, data = connection.list(source_mailbox)
             for d in data:
                 if d:
-                    new_source_mailbox = d.split('"')[3]  # Getting submailbox name
-                    if new_source_mailbox.count('/') == recurse_level:
-                        self.logger.info("Recursing into %s" % new_source_mailbox)
-                        new_destination_mailbox = new_source_mailbox.split("/")[recurse_level]
-                        self.copy(new_source_mailbox, destination_mailbox + self.delimiter + new_destination_mailbox,
-                                  skip, limit, recurse_level + 1)
+                    if '\HasNoChildren' in d:
+                      self.logger.info("No further recursion needed")
+                    else:
+                      new_source_mailbox = d.split('"')[3]  # Getting submailbox name
+                      if new_source_mailbox.count('/') == recurse_level:
+                          self.logger.info("Recursing into %s" % new_source_mailbox)
+                          new_destination_mailbox = new_source_mailbox.split("/")[recurse_level]
+                          self.copy(new_source_mailbox, destination_mailbox + self.delimiter + new_destination_mailbox,
+                                    skip, limit, recurse_level + 1)
 
         # There should be no files stored in / so we are bailing out
         if source_mailbox == '':


### PR DESCRIPTION
This fixes the recursion bug on servers that return \HasNoChildren for the list command on folders with no child folders present.

This fixes bug: https://github.com/jarus/imap_copy/issues/2